### PR TITLE
rfc(glue): Implement WebGlue and createIosSocket

### DIFF
--- a/src/glue/index.ts
+++ b/src/glue/index.ts
@@ -1,0 +1,20 @@
+import { Buffer } from "https://deno.land/std@0.137.0/io/buffer.ts";
+import { str2u8s } from "./misc.ts";
+
+const key = "glue"; // TODO: use less conflicting name
+
+export interface Glue {
+  read(p: Uint8Array): Promise<number | null>;
+  recv(data: Uint8Array | string): Promise<number>;
+}
+export function getGlue(): Glue {
+  const global = globalThis as any;
+  if (global[key]) return global[key];
+  const buffer = new Buffer(new Uint8Array(1024));
+  const glue: Glue = {
+    read: (data) => buffer.read(data),
+    recv: (data) =>
+      buffer.write(typeof data === "string" ? str2u8s(data) : data),
+  };
+  return global[key] = glue;
+}

--- a/src/glue/index.ts
+++ b/src/glue/index.ts
@@ -5,7 +5,7 @@ import {
 import { chain } from "../misc.ts";
 import { str2u8s } from "./misc.ts";
 
-const key = "glue"; // TODO: use less conflicting name
+const key = "<glue>";
 
 export interface Glue extends Deno.Reader {
   recv(data: Uint8Array | string): void;

--- a/src/glue/index.ts
+++ b/src/glue/index.ts
@@ -1,20 +1,40 @@
-import { Buffer } from "https://deno.land/std@0.137.0/io/buffer.ts";
+import {
+  defer,
+  Deferred,
+} from "https://deno.land/x/pbkit@v0.0.45/core/runtime/async/observer.ts";
+import { chain } from "../misc.ts";
 import { str2u8s } from "./misc.ts";
 
 const key = "glue"; // TODO: use less conflicting name
 
-export interface Glue {
-  read(p: Uint8Array): Promise<number | null>;
-  recv(data: Uint8Array | string): Promise<number>;
+export interface Glue extends Deno.Reader {
+  recv(data: Uint8Array | string): void;
 }
 export function getGlue(): Glue {
   const global = globalThis as any;
   if (global[key]) return global[key];
-  const buffer = new Buffer(new Uint8Array(1024));
+  const queue: Uint8Array[] = [];
+  let wait: Deferred<void> | undefined;
   const glue: Glue = {
-    read: (data) => buffer.read(data),
-    recv: (data) =>
-      buffer.write(typeof data === "string" ? str2u8s(data) : data),
+    recv: (data) => {
+      queue.push(typeof data === "string" ? str2u8s(data) : data);
+      wait?.resolve();
+    },
+    read: chain(async (data) => {
+      if (queue.length < 1) {
+        await (wait = defer());
+        wait = undefined;
+      }
+      const first = queue[0];
+      if (first.length <= data.length) {
+        queue.shift();
+        data.set(first);
+        return first.length;
+      }
+      data.set(first.subarray(0, data.length));
+      queue[0] = first.subarray(data.length);
+      return data.length;
+    }),
   };
   return global[key] = glue;
 }

--- a/src/glue/ios.ts
+++ b/src/glue/ios.ts
@@ -1,54 +1,22 @@
-import { Buffer } from "https://deno.land/std@0.122.0/io/buffer.ts";
 import { Socket } from "../socket.ts";
-import { str2u8s } from "./misc.ts";
+import { tryUntilSuccess } from "./misc.ts";
+import { getGlue } from "./index.ts";
 
-declare global {
-  interface Window {
-    webkit?: {
-      messageHandlers?: {
-        glue?: {
-          postMessage(message: {
-            data: Uint8Array;
-          }): Promise<void>;
-        };
-      };
-    };
-    glue: WebGlue;
-  }
-}
-
-interface WebGlue {
-  read(p: Uint8Array): Promise<number | null>;
-  recv(data: string): Promise<number>;
-}
-export function registerWebGlue() {
-  const buf = new Buffer(new Uint8Array(1024));
-  Object.assign(window, {
-    glue: {
-      read(p: Uint8Array) {
-        return buf.read(p);
-      },
-      recv(data: string) {
-        return buf.write(str2u8s(data));
-      },
+export async function createIosSocket(): Promise<Socket> {
+  const iosGlue = await getIosGlue();
+  return {
+    read: getGlue().read,
+    async write(data) {
+      return iosGlue.postMessage({ data }).then(() => data.byteLength);
     },
-  });
+  };
 }
 
-export async function createIosSocket() {
-  return new Promise<Socket>((resolve, reject) => {
-    const glue = window.webkit?.messageHandlers?.glue;
-    if (!glue) reject(new Error("No glue in messageHandlers")); // Retry strategy for this?
-    return resolve({
-      read(p) {
-        return window.glue.read(p);
-      },
-      async write(p) {
-        if (!glue) throw new Error("Unreachable code");
-        return glue.postMessage({ data: p }).then(() => {
-          return p.byteLength;
-        });
-      },
-    });
-  });
+interface IosGlue {
+  postMessage(message: { data: Uint8Array }): Promise<void>;
+}
+async function getIosGlue(): Promise<IosGlue> {
+  return await tryUntilSuccess(
+    () => (globalThis as any).webkit?.messageHandlers?.glue || undefined,
+  );
 }

--- a/src/glue/ios.ts
+++ b/src/glue/ios.ts
@@ -1,0 +1,54 @@
+import { Buffer } from "https://deno.land/std@0.122.0/io/buffer.ts";
+import { Socket } from "../socket.ts";
+import { str2u8s } from "./misc.ts";
+
+declare global {
+  interface Window {
+    webkit?: {
+      messageHandlers?: {
+        glue?: {
+          postMessage(message: {
+            data: Uint8Array;
+          }): Promise<void>;
+        };
+      };
+    };
+    glue: WebGlue;
+  }
+}
+
+interface WebGlue {
+  read(p: Uint8Array): Promise<number | null>;
+  recv(data: string): Promise<number>;
+}
+export function registerWebGlue() {
+  const buf = new Buffer(new Uint8Array(1024));
+  Object.assign(window, {
+    glue: {
+      read(p: Uint8Array) {
+        return buf.read(p);
+      },
+      recv(data: string) {
+        return buf.write(str2u8s(data));
+      },
+    },
+  });
+}
+
+export async function createIosSocket() {
+  return new Promise<Socket>((resolve, reject) => {
+    const glue = window.webkit?.messageHandlers?.glue;
+    if (!glue) reject(new Error("No glue in messageHandlers")); // Retry strategy for this?
+    return resolve({
+      read(p) {
+        return window.glue.read(p);
+      },
+      async write(p) {
+        if (!glue) throw new Error("Unreachable code");
+        return glue.postMessage({ data: p }).then(() => {
+          return p.byteLength;
+        });
+      },
+    });
+  });
+}

--- a/src/glue/misc.ts
+++ b/src/glue/misc.ts
@@ -11,3 +11,24 @@ export function str2u8s(str: string): Uint8Array {
     }),
   );
 }
+
+export type TryFn<T> = () => T | undefined;
+export function tryUntilSuccess<T>(
+  fn: TryFn<T>,
+  interval: number = 100,
+  limit: number = 10,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    let count = 0;
+    const intervalId = setInterval(() => {
+      const result = fn();
+      if (result !== undefined) {
+        clearInterval(intervalId);
+        resolve(result);
+      } else if (++count >= limit) {
+        clearInterval(intervalId);
+        reject(new Error("Exhausted all retries"));
+      }
+    }, interval);
+  });
+}

--- a/src/glue/misc.ts
+++ b/src/glue/misc.ts
@@ -1,15 +1,11 @@
 export function u8s2str(u8s: Uint8Array): string {
-  return Array.from(u8s).map((u8) => String.fromCharCode(u8)).join("");
+  return u8s.reduce((acc, curr) => acc + String.fromCharCode(curr), "");
 }
 
 export function str2u8s(str: string): Uint8Array {
-  return new Uint8Array(
-    Array.from(str).map((char) => {
-      const code = char.codePointAt(0);
-      if (code == null) throw new Error("Unexpected character");
-      return code;
-    }),
-  );
+  const u8s = new Uint8Array(str.length);
+  for (let i = 0; i < str.length; ++i) u8s[i] = str.charCodeAt(i);
+  return u8s;
 }
 
 export type TryFn<T> = () => T | undefined;


### PR DESCRIPTION
Swift side will call `globalThis["<glue>"].recv` for sending data(UTF-8 encoded bytes).
Web-client will call `globalThis.webkit.messageHandlers.glue.postMessage` for sending data.
I think that sending to the swift side doesn't require utf-8 encoding, just send raw Uint8Array.
I checked that data is received but needs investigation about its swift type.
